### PR TITLE
shorten method name

### DIFF
--- a/src/main/java/com/madhukartemba/smarttest/util/Updater.java
+++ b/src/main/java/com/madhukartemba/smarttest/util/Updater.java
@@ -160,7 +160,7 @@ public class Updater {
     }
 
     public static int checkForUpdates(boolean silent) throws Exception {
-        String GITHUB_VERSION = getVersionNumberFromGithub(VERSION_URL, silent);
+        String GITHUB_VERSION = getVersionNumFromGithub(VERSION_URL, silent);
         if (GITHUB_VERSION == null) {
             return silent ? 0 : 1;
         }
@@ -176,7 +176,7 @@ public class Updater {
 
     }
 
-    private static String getVersionNumberFromGithub(String rawUrl, boolean silent) throws Exception {
+    private static String getVersionNumFromGithub(String rawUrl, boolean silent) throws Exception {
 
         if (GITHUB_VERSION != null) {
             return GITHUB_VERSION;


### PR DESCRIPTION
Shorten method name "getVersionNumberFromGithub" by replacing "Number" with "Num". The short method name still follows a standard naming convention and accurately describes the purpose of the method in a more concise way. The short name is easier to read and type.